### PR TITLE
Search for libdvdcss in the app's Resources dir.

### DIFF
--- a/Fairmount.mm
+++ b/Fairmount.mm
@@ -1,4 +1,3 @@
-
 #import "Fairmount.h"
 #import "Overlay.h"
 #include "Decryption.h"
@@ -455,6 +454,7 @@ error:
 - (void) awakeFromNib
 {
     NSArray *libPaths = [NSArray arrayWithObjects:
+                             [[NSBundle mainBundle] pathForResource:@"libdvdcss.2" ofType:@"dylib"],
                              INSTALL_PATH,
                              [@"~/Library/Application Support/Fairmount/libdvdcss.2.dylib" stringByExpandingTildeInPath],
                              @"/usr/lib/libdvdcss.2.dylib",


### PR DESCRIPTION
First look for libdvdcss.2.dylib in Fairmount.app/Contents/Resources/
This is useful for those who don't want to put the dylib in /usr/lib or in "~/Library/Application Support/Fairmount", just keep it all in the app bundle.
