### PR TITLE
Changes to build on MacOS X 10.11

### DIFF
--- a/CSSFileAccess.cpp
+++ b/CSSFileAccess.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unistd.h>
 #include <assert.h>
+#include <pthread.h>
 
 //-------------------------------------------------------------------------
 typedef struct

--- a/Fairmount.mm
+++ b/Fairmount.mm
@@ -454,10 +454,11 @@ error:
 - (void) awakeFromNib
 {
     NSArray *libPaths = [NSArray arrayWithObjects:
-                             [[NSBundle mainBundle] pathForResource:@"libdvdcss.2" ofType:@"dylib"],
                              INSTALL_PATH,
                              [@"~/Library/Application Support/Fairmount/libdvdcss.2.dylib" stringByExpandingTildeInPath],
                              @"/usr/lib/libdvdcss.2.dylib",
+                             @"/opt/local/lib/libdvdcss.2.dylib",
+                             [[NSBundle mainBundle] pathForResource:@"libdvdcss.2" ofType:@"dylib"],
                              nil];
     BOOL found;
 

--- a/Fairmount.xcodeproj/project.pbxproj
+++ b/Fairmount.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				);
 				PRODUCT_NAME = Fairmount;
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = NO;
@@ -395,7 +395,7 @@
 				);
 				PRODUCT_NAME = Fairmount;
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = YES;
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = NO;

--- a/FileAccess.cpp
+++ b/FileAccess.cpp
@@ -8,6 +8,7 @@
 #include <sys/errno.h>
 #include <string>
 #include <assert.h>
+#include <pthread.h>
 
 //-------------------------------------------------------------------------
 class FileAccess : public IFileAccess


### PR DESCRIPTION
Updated to build on MacOS X 10.11. Changes include:
- inclusion of pthreads.h
- adjusted order of paths in libPaths, to deal with
  a possible nil result for pathForResource, which
  would result in a zero length list

Fixes issue #5
